### PR TITLE
fix: update manual release workflow to push new branch to remote before semantic release

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -56,10 +56,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_TYPE: ${{ inputs.releaseType }}
         run: |
-          # Configure git to push to the release branch
-          git branch --set-upstream-to=origin/$BRANCH_NAME $BRANCH_NAME
+          # Push the new branch to remote first
+          git push -u origin $BRANCH_NAME
           npx semantic-release
-
+  
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
## Description

fix: update manual release workflow to push new branch to remote before semantic release

## Change Type

<!--- This is a comment, you can leave this to give information to the contributor -->

- [ ] Bug fix 
- [ ] New feature
- [ ] Breaking change
- [ ] Minor changes in old functionality

## Checklist

- [ ] My changes are well-tested and commented
- [ ] I reviewed my changes
- [ ] My changes generate no new warnings