### PR TITLE
fix(aws): update CloudFormationParser to use formatted YAML content

### DIFF
--- a/src/parsers/aws-cloudformation.ts
+++ b/src/parsers/aws-cloudformation.ts
@@ -184,12 +184,12 @@ class CloudFormationParser extends BaseParser {
     };
 
     // Process the output based on format
-    const content = JSON.stringify(response, null, 2);
-    const formattedContent = this.replaceSpecialDirectives(content);
+    const yamlContent = this.formatFileContent(response, TemplateFormat.yaml);
+    const formattedContent = this.replaceSpecialDirectives(yamlContent);
 
     return {
       'aws-cloudformation.cf.yml': {
-        content: this.formatFileContent(formattedContent, TemplateFormat.yaml),
+        content: formattedContent,
         format: TemplateFormat.yaml,
         isMain: true
       }


### PR DESCRIPTION
## Description

fix(aws): update CloudFormationParser to use formatted YAML content

## Change Type

<!--- This is a comment, you can leave this to give information to the contributor -->

- [ ] Bug fix 
- [ ] New feature
- [ ] Breaking change
- [ ] Minor changes in old functionality

## Checklist

- [ ] My changes are well-tested and commented
- [ ] I reviewed my changes
- [ ] My changes generate no new warnings