### PR TITLE
chore(release): prepare release v1.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.21.3](https://github.com/deploystackio/docker-to-iac/compare/v1.21.2...v1.21.3) (2025-04-11)
+### Chores
+
+* chore: bump @eslint/js from 9.23.0 to 9.24.0 [9ebdc18]
+* chore: bump @types/node from 22.13.14 to 22.14.0 [8942a46]
+* chore: bump @typescript-eslint/parser from 8.28.0 to 8.29.0 [28ad47f]
+* chore: bump @typescript-eslint/eslint-plugin from 8.28.0 to 8.29.0 [8132e03]
+* chore: bump eslint from 9.23.0 to 9.24.0 [9b69589]
+
+
+
+### Bug Fixes
+* **run-command-parser:** improve argument parsing for docker run commands ([dd8f479](https://github.com/deploystackio/docker-to-iac/commit/dd8f4796eeb41f061584f8f1aed01da9148216c1))
+
 ## [1.21.2](https://github.com/deploystackio/docker-to-iac/compare/v1.21.1...v1.21.2) (2025-04-06)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deploystack/docker-to-iac",
-  "version": "1.21.2",
+  "version": "1.21.3",
   "main": "dist/src/index.js",
   "scripts": {
     "pretest": "rm -rf test/output/docker-compose test/output/docker-run",


### PR DESCRIPTION
## Description

### Chores

* chore: bump @eslint/js from 9.23.0 to 9.24.0 [9ebdc18]
* chore: bump @types/node from 22.13.14 to 22.14.0 [8942a46]
* chore: bump @typescript-eslint/parser from 8.28.0 to 8.29.0 [28ad47f]
* chore: bump @typescript-eslint/eslint-plugin from 8.28.0 to 8.29.0 [8132e03]
* chore: bump eslint from 9.23.0 to 9.24.0 [9b69589]

### Bug Fixes

* **run-command-parser:** improve argument parsing for docker run commands ([dd8f479](https://github.com/deploystackio/docker-to-iac/commit/dd8f4796eeb41f061584f8f1aed01da9148216c1))

## Change Type

<!--- This is a comment, you can leave this to give information to the contributor -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Release
- [ ] Minor changes in old functionality

## Checklist

- [x] My changes are well-tested and commented
- [x] I reviewed my changes
- [x] My changes generate no new warnings
