### PR TITLE
fix: add missing comma in tsconfig.json types array

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "declaration": true,
     "outDir": "./dist",
     "rootDir": ".",
-    "types": ["node"]  
+    "types": ["node"],
+    "skipLibCheck": true    
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
## Description

fix: add missing comma in tsconfig.json types array

## Change Type

<!--- This is a comment, you can leave this to give information to the contributor -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Release
- [ ] Minor changes in old functionality

## Checklist

- [ ] My changes are well-tested and commented
- [ ] I reviewed my changes
- [ ] My changes generate no new warnings
